### PR TITLE
Add tip calculator command-line app

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ will count toward the event.
 | [BMI Calculator](apps/bmi_calculator) | Python | Compute body mass index and return a weight classification. |
 | [Password Generator](apps/password-generator) | Node.js | Generate secure random passwords from the command line with customizable options. |
 | [QR Code Generator](apps/qr-generator) | Python | Generate QR codes from text or URLs with multiple output formats (PNG, SVG, ASCII) and customization options. |
+| [Tip Calculator](apps/tip-calculator) | Python | Calculate tip, total, and per-person amounts with optional rounding for even splits. |
 
 ## Code of Conduct
 

--- a/apps/tip-calculator/README.md
+++ b/apps/tip-calculator/README.md
@@ -1,0 +1,24 @@
+# Tip Calculator
+
+A lightweight Python command-line tool that helps you calculate restaurant tips and split bills between friends in seconds.
+
+## Features
+
+- Calculates tip amount and total cost based on a percentage you choose
+- Splits the bill evenly across any number of people
+- Optional rounding so everyone pays the same amount to the nearest cent
+- Includes a reusable module for other Python projects
+
+## Getting Started
+
+```bash
+python tip_calculator.py 85.40 --tip 18 --people 3 --round
+```
+
+This command will output a neatly formatted breakdown showing the tip, total, and per-person amounts. Use `--help` to see all options.
+
+## Running Tests
+
+```bash
+pytest apps/tip-calculator/tests
+```

--- a/apps/tip-calculator/tests/test_tip_calculator.py
+++ b/apps/tip-calculator/tests/test_tip_calculator.py
@@ -1,0 +1,71 @@
+"""Tests for the tip calculator module."""
+
+import math
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from tip_calculator import TipBreakdown, calculate_tip, calculate_tip_from_cli, format_breakdown
+
+
+def test_calculate_tip_basic():
+    breakdown = calculate_tip(100, 20)
+
+    assert isinstance(breakdown, TipBreakdown)
+    assert breakdown.tip_amount == 20
+    assert breakdown.total_amount == 120
+    assert breakdown.amount_per_person == 120
+
+
+def test_calculate_tip_split_evenly():
+    breakdown = calculate_tip(80, 18, num_people=4)
+
+    assert breakdown.tip_amount == 14.4
+    assert breakdown.total_amount == 94.4
+    assert breakdown.amount_per_person == 23.6
+
+
+def test_calculate_tip_round_up():
+    breakdown = calculate_tip(53.27, 18, num_people=3, round_up=True)
+
+    assert math.isclose(breakdown.amount_per_person, 20.96)
+    assert math.isclose(breakdown.total_amount, 62.88)
+    assert math.isclose(breakdown.tip_amount, 9.61, abs_tol=0.01)
+
+
+def test_calculate_tip_invalid_inputs():
+    invalid_args = [
+        (-10, 15, 1),
+        (10, -5, 1),
+        (10, 15, 0),
+    ]
+
+    for bill, tip, people in invalid_args:
+        try:
+            calculate_tip(bill, tip, people)
+            raise AssertionError("Expected ValueError")
+        except ValueError:
+            pass
+
+
+def test_format_breakdown_output():
+    breakdown = calculate_tip(45.5, 22, num_people=2)
+    output = format_breakdown(breakdown)
+
+    assert "Bill Amount: $45.50" in output
+    assert "Tip Percentage: 22.0%" in output
+    assert "Number of People: 2" in output
+    assert "Tip Amount: $10.01" in output
+    assert "Total Amount: $55.51" in output
+    assert "Amount Per Person: $27.76" in output
+
+
+def test_calculate_tip_from_cli_arguments():
+    args = {"bill": "75.5", "tip": "18", "people": "3", "round": "true"}
+    breakdown = calculate_tip_from_cli(args)
+
+    assert breakdown.num_people == 3
+    assert math.isclose(breakdown.tip_amount, 13.59, abs_tol=0.01)
+
+

--- a/apps/tip-calculator/tip_calculator.py
+++ b/apps/tip-calculator/tip_calculator.py
@@ -1,0 +1,136 @@
+"""Simple tip calculator module."""
+from dataclasses import dataclass
+from decimal import Decimal, ROUND_CEILING, ROUND_HALF_UP
+from typing import Dict
+
+
+@dataclass(frozen=True)
+class TipBreakdown:
+    """Represents calculated tip information."""
+
+    bill_amount: float
+    tip_percent: float
+    num_people: int
+    tip_amount: float
+    total_amount: float
+    amount_per_person: float
+
+
+def calculate_tip(
+    bill_amount: float,
+    tip_percent: float,
+    num_people: int = 1,
+    round_up: bool = False,
+) -> TipBreakdown:
+    """Calculate tip and totals.
+
+    Args:
+        bill_amount: Original bill before tip.
+        tip_percent: Tip percentage (e.g. 20 for 20%).
+        num_people: How many people split the bill.
+        round_up: Whether to round the per-person amount up to the nearest cent.
+
+    Returns:
+        TipBreakdown containing calculation results.
+
+    Raises:
+        ValueError: If inputs are invalid.
+    """
+
+    if bill_amount < 0:
+        raise ValueError("bill_amount must be non-negative")
+    if tip_percent < 0:
+        raise ValueError("tip_percent must be non-negative")
+    if num_people <= 0:
+        raise ValueError("num_people must be greater than zero")
+
+    bill = Decimal(str(bill_amount)).quantize(Decimal("0.01"), rounding=ROUND_HALF_UP)
+    tip_pct = Decimal(str(tip_percent))
+
+    tip_amount = (bill * tip_pct / Decimal("100")).quantize(
+        Decimal("0.01"), rounding=ROUND_HALF_UP
+    )
+    total_amount = (bill + tip_amount).quantize(Decimal("0.01"), rounding=ROUND_HALF_UP)
+
+    if round_up:
+        amount_per_person = (total_amount / num_people).quantize(
+            Decimal("0.01"), rounding=ROUND_CEILING
+        )
+        total_amount = (amount_per_person * num_people).quantize(
+            Decimal("0.01"), rounding=ROUND_HALF_UP
+        )
+        tip_amount = (total_amount - bill).quantize(
+            Decimal("0.01"), rounding=ROUND_HALF_UP
+        )
+    else:
+        amount_per_person = (total_amount / num_people).quantize(
+            Decimal("0.01"), rounding=ROUND_HALF_UP
+        )
+
+    return TipBreakdown(
+        bill_amount=float(bill),
+        tip_percent=float(tip_percent),
+        num_people=num_people,
+        tip_amount=float(tip_amount),
+        total_amount=float(total_amount),
+        amount_per_person=float(amount_per_person),
+    )
+
+
+def format_breakdown(breakdown: TipBreakdown) -> str:
+    """Format a tip breakdown for display."""
+
+    return (
+        f"Bill Amount: ${breakdown.bill_amount:.2f}\n"
+        f"Tip Percentage: {breakdown.tip_percent:.1f}%\n"
+        f"Number of People: {breakdown.num_people}\n"
+        f"Tip Amount: ${breakdown.tip_amount:.2f}\n"
+        f"Total Amount: ${breakdown.total_amount:.2f}\n"
+        f"Amount Per Person: ${breakdown.amount_per_person:.2f}"
+    )
+
+
+def calculate_tip_from_cli(args: Dict[str, str]) -> TipBreakdown:
+    """Helper to calculate tip using CLI-style arguments."""
+
+    bill_amount = float(args.get("bill", 0))
+    tip_percent = float(args.get("tip", 20))
+    num_people = int(args.get("people", 1))
+    round_up = args.get("round", "false").lower() in {"true", "1", "yes", "y"}
+
+    return calculate_tip(bill_amount, tip_percent, num_people, round_up)
+
+
+if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Calculate restaurant tips with ease.")
+    parser.add_argument("bill", type=float, help="Bill amount before tip")
+    parser.add_argument(
+        "--tip",
+        type=float,
+        default=20,
+        help="Tip percentage to apply (default: 20)",
+    )
+    parser.add_argument(
+        "--people",
+        type=int,
+        default=1,
+        help="Number of people splitting the bill (default: 1)",
+    )
+    parser.add_argument(
+        "--round",
+        action="store_true",
+        help="Round up the per-person amount to the nearest cent",
+    )
+
+    parsed_args = parser.parse_args()
+
+    breakdown = calculate_tip(
+        bill_amount=parsed_args.bill,
+        tip_percent=parsed_args.tip,
+        num_people=parsed_args.people,
+        round_up=parsed_args.round,
+    )
+
+    print(format_breakdown(breakdown))


### PR DESCRIPTION
## Summary
- add a Python tip calculator module and CLI that supports bill splitting and optional rounding
- document the new app and link it from the project overview
- cover the calculator with unit tests and CLI argument checks

## Testing
- pytest apps/tip-calculator/tests

------
https://chatgpt.com/codex/tasks/task_e_68e4fb00a7588328a99a506adf673618